### PR TITLE
Assume empty Accept-Language header when not present

### DIFF
--- a/lib/plug_best.ex
+++ b/lib/plug_best.ex
@@ -67,9 +67,11 @@ defmodule PlugBest do
 
   @spec fetch_header_value(%Conn{}, String.t) :: String.t
   defp fetch_header_value(conn, header_name) do
-    conn
+    header_value = conn
     |> Conn.get_req_header(header_name)
     |> List.first
+
+    header_value || ""
   end
 
   @spec parse_header_value_item(String.t) :: language

--- a/test/plug_best_test.exs
+++ b/test/plug_best_test.exs
@@ -17,6 +17,13 @@ defmodule PlugBestTest do
     assert best_language == {"en", "en", 0.6}
   end
 
+  test "returns nil when there is no accept-language header" do
+    conn = %Plug.Conn{req_headers: []}
+
+    best_language = conn |> PlugBest.best_language(["de", "ru"])
+    assert best_language == nil
+  end
+
   test "returns nil when there is no best language" do
     conn = %Plug.Conn{req_headers: [{"accept-language", "fr-CA,fr;q=0.8,en;q=0.6,en-US;q=0.4"}]}
 


### PR DESCRIPTION
We need to make sure `fetch_header_value` always return a string, even if the `Accept-Language` header is not present in the request.
