### PR TITLE
Rewrite most of the code to support more headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Travis](https://img.shields.io/travis/remiprev/plug_best.svg?style=flat-square)](https://travis-ci.org/remiprev/plug_best)
 [![Hex.pm](https://img.shields.io/hexpm/v/plug_best.svg?style=flat-square)](https://hex.pm/packages/plug_best)
 
-`PlugBest` parses HTTP “Accept-*“ headers and returns the best match based on a list of values.
+`PlugBest` parses HTTP `Accept-*` headers and returns the best match based on a list of values.
 
 ## Installation
 
@@ -22,15 +22,16 @@ Then run `mix do deps.get, deps.compile` inside your project's directory.
 
 ## Usage
 
-`PlugBest` currently provides a single basic method:
+`PlugBest` currently provides eight methods:
 
 * `best_language/2`
-
-And plans to add support for the following soon:
-
+* `best_language_or_first/2`
 * `best_charset/2`
+* `best_charset_or_first/2`
 * `best_encoding/2`
-* `best_media_type/2`
+* `best_encoding_or_first/2`
+* `best_type/2`
+* `best_type_or_first/2`
 
 To find out which language is the best one to use among a list of supported languages:
 

--- a/test/plug_best_test.exs
+++ b/test/plug_best_test.exs
@@ -17,6 +17,13 @@ defmodule PlugBestTest do
     assert best_language_from_es_en == {"en", "en", 0.6}
   end
 
+  test "returns the best type" do
+    conn = %Plug.Conn{req_headers: [{"accept", "application/json;q=0.4,application/xml;q=0.5,text/csv;q=0.9"}]}
+
+    best_type = conn |> PlugBest.best_type(["application/json", "text/csv"])
+    assert best_type == {"text/csv", "text/csv", 0.9}
+  end
+
   test "handles malformed header value" do
     conn = %Plug.Conn{req_headers: [{"accept-language", "fr-CA;q=1,fr;q=0.8,en;q=0.6,en-US;q=0.4"}]}
 


### PR DESCRIPTION
We now support:

* `best_language/2`
* `best_language_or_first/2`
* `best_charset/2`
* `best_charset_or_first/2`
* `best_encoding/2`
* `best_encoding_or_first/2`
* `best_type/2`
* `best_type_or_first/2`

🎉 