### PR TITLE
Do not use HEX_API_KEY in Hex.pm publish dry run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
       - run: make test
       - run: mix hex.publish --dry-run
         env:
-          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+          HEX_API_KEY: DRYRUN


### PR DESCRIPTION
The `mix hex.publish --dry-run` command requires authentication even though it doesn’t end up using it.

So we need to keep passing the `HEX_API_KEY` environment variable but with a dummy value.
